### PR TITLE
clean up gemspec by removing rubyforge_project line

### DIFF
--- a/letsfreckle-client.gemspec
+++ b/letsfreckle-client.gemspec
@@ -12,8 +12,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Ruby client for letsfreckle.com API}
   s.description = %q{Ruby client for letsfreckle.com API that supports entries, projects, tags, and users}
 
-  s.rubyforge_project = "letsfreckle-client"
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- spec/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
Hey Ryan,

I don't think we need this line for RubyForge, unless you're planning to publish the project there?
